### PR TITLE
Fix some broken links

### DIFF
--- a/contents/best-practice-1-writing-better-elisp.rst
+++ b/contents/best-practice-1-writing-better-elisp.rst
@@ -43,6 +43,6 @@ Additional Reading
 
 There are more `Coding Conventions`_ for writing Elisp additional and rules about `Key-Binding Conventions`_ in the *Emacs Lisp Reference Manual*.
 
-.. _Coding Conventions: http://www.gnu.org/software/emacs/Elisp/html_node/Coding-Conventions.html#Coding-Conventions
+.. _Coding Conventions: http://www.gnu.org/software/emacs/elisp/html_node/Coding-Conventions.html#Coding-Conventions
 
-.. _Key-Binding Conventions: http://www.gnu.org/s/emacs/manual/html_node/Elisp/Key-Binding-Conventions.html#Key-Binding-Conventions
+.. _Key-Binding Conventions: http://www.gnu.org/s/emacs/manual/html_node/elisp/Key-Binding-Conventions.html#Key-Binding-Conventions

--- a/contents/lesson-2-1-first-elisp-programme.rst
+++ b/contents/lesson-2-1-first-elisp-programme.rst
@@ -91,4 +91,4 @@ What do you think these symbols represent?
 | ``-1.0e+INF``
 | ``0.0e+NaN`` or ``-0.0e+NaN``
 
-.. _GNU Emacs Lisp Reference Manual: http://www.gnu.org/software/emacs/emacs-lisp-intro/Elisp/Numbers.html#Numbers
+.. _GNU Emacs Lisp Reference Manual: http://www.gnu.org/software/emacs/emacs-lisp-intro/elisp/Numbers.html#Numbers

--- a/contents/lesson-2-2-primitive-data-types-1.rst
+++ b/contents/lesson-2-2-primitive-data-types-1.rst
@@ -220,4 +220,4 @@ What do the following functions do:
 * ``ceiling``
 * ``floor``
 
-.. _GNU Emacs Lisp Reference Manual: http://www.gnu.org/software/emacs/emacs-lisp-intro/Elisp/Lisp-Data-Types.html#Lisp-Data-Types
+.. _GNU Emacs Lisp Reference Manual: http://www.gnu.org/software/emacs/emacs-lisp-intro/elisp/Lisp-Data-Types.html#Lisp-Data-Types

--- a/contents/lesson-2-4-symbols-and-variables.rst
+++ b/contents/lesson-2-4-symbols-and-variables.rst
@@ -168,6 +168,6 @@ However if we now evaluate the value of ``hotdog`` you will see that it is ``(:q
 
 What happens if you try and set the property list of an undefined symbol?
 
-.. _Symbols: http://www.gnu.org/software/emacs/emacs-lisp-intro/Elisp/Symbol-Components.html#Symbol-Components
+.. _Symbols: http://www.gnu.org/software/emacs/emacs-lisp-intro/elisp/Symbol-Components.html#Symbol-Components
 
-.. _Symbol Properties: http://www.gnu.org/software/emacs/Elisp/html_node/Symbol-Plists.html#Symbol-Plists
+.. _Symbol Properties: http://www.gnu.org/software/emacs/elisp/html_node/Symbol-Plists.html#Symbol-Plists

--- a/contents/lesson-3-1-writing-functions.rst
+++ b/contents/lesson-3-1-writing-functions.rst
@@ -147,5 +147,5 @@ Write a function with multiple line documentation.
 The *required*, *optional* and *rest* clauses must be specified in that order. Can you work out why? 
 
 
-.. _Functions: http://www.gnu.org/software/emacs/Elisp/html_node/Functions.html#Functions
+.. _Functions: http://www.gnu.org/software/emacs/elisp/html_node/Functions.html#Functions
 

--- a/contents/lesson-4-1-writing-elisp-in-emacs.rst
+++ b/contents/lesson-4-1-writing-elisp-in-emacs.rst
@@ -46,4 +46,4 @@ Extra Activities
 
 Run the menu item *Check Document Strings* in the *Emacs-Lisp* menu - can you work out what does the operator ``provide`` does?
 
-.. _Emacs Manual: http://www.gnu.org/software/emacs/manual/html_node/Elisp/Using-Edebug.html#Using-Edebug
+.. _Emacs Manual: http://www.gnu.org/software/emacs/manual/html_node/elisp/Using-Edebug.html#Using-Edebug

--- a/contents/lesson-4-2-adding-custom-functions-to-emacs.rst
+++ b/contents/lesson-4-2-adding-custom-functions-to-emacs.rst
@@ -142,8 +142,8 @@ Experiment with other Interactive Codes in your functions.
 
 Bind and unbind some keys to functions in your ``.emacs`` file.
 
-.. _Interactive Codes: http://www.gnu.org/software/emacs/Elisp/html_node/Interactive-Codes.html#Interactive-Codes
+.. _Interactive Codes: http://www.gnu.org/software/emacs/elisp/html_node/Interactive-Codes.html#Interactive-Codes
 
 .. _Key Bindings: http://www.gnu.org/software/emacs/emacs-lisp-intro/html_node/Keybindings.html#Keybindings
 
-.. _Keymaps: http://www.gnu.org/s/emacs/manual/html_node/Elisp/Keymaps.html#Keymaps
+.. _Keymaps: http://www.gnu.org/s/emacs/manual/html_node/elisp/Keymaps.html#Keymaps

--- a/contents/lesson-5-1-elisp-in-files.rst
+++ b/contents/lesson-5-1-elisp-in-files.rst
@@ -99,4 +99,4 @@ Additional Reading
 
 There is a slightly more to loading code in Elisp which is described in the `Loading Code`_ section of the Elisp Reference Manual.
 
-.. _Loading Code: http://www.gnu.org/software/emacs/emacs-lisp-intro/Elisp/How-Programs-Do-Loading.html#How-Programs-Do-Loading
+.. _Loading Code: http://www.gnu.org/software/emacs/emacs-lisp-intro/elisp/How-Programs-Do-Loading.html#How-Programs-Do-Loading

--- a/contents/references.rst
+++ b/contents/references.rst
@@ -13,6 +13,6 @@ Where appropriate this book will refer you to these works for further reading.
 
 .. _An Introduction To Programming In Elisp: http://www.gnu.org/software/emacs/emacs-lisp-intro/
 
-.. _GNU Emacs Lisp Reference Manual: http://www.gnu.org/software/emacs/emacs-lisp-intro/Elisp/index.html#Top
+.. _GNU Emacs Lisp Reference Manual: http://www.gnu.org/software/emacs/emacs-lisp-intro/elisp/index.html#Top
 
 .. _Writing GNU Emacs Extensions: http://astore.amazon.com/hypernumbersc-20/detail/1565922611


### PR DESCRIPTION
Some links are broken (e.g. http://www.gnu.org/software/emacs/manual/html_node/Elisp/Using-Edebug.html#Using-Edebug in Lesson 4.1), fix them by replace /Elisp/ with /elisp/
