### PR TITLE
Remove comments template from conf.py for later Sphinx compatibility.

### DIFF
--- a/_build/html/.buildinfo
+++ b/_build/html/.buildinfo
@@ -1,4 +1,4 @@
 # Sphinx build info version 1
 # This file hashes the configuration used when building these files. When it is not found, a full rebuild will be done.
-config: 524d1b55c662a7d873df5e2fe4c0afd5
-tags: fbb0d17656682115ca4d033fb2f83ba1
+config: 4f415f4b45c192b1a63cd2662957dad0
+tags: 645f666f9bcd5a90fca523b33c5a78b7

--- a/conf.py
+++ b/conf.py
@@ -151,7 +151,9 @@ html_static_path = ['_static']
 #html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {'index' : 'comments.html'}
+html_sidebars = {
+    #'index' : 'comments.html',   ## removed for compatibility with Sphinx 1.
+}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.


### PR DESCRIPTION
`make html` fails when using recent Sphinx versions (tested 1.8.5 and 6.0.0b2) because Jinja2 cannot find "comments.html". (This root cause was not obvious from the Sphinx error messages.) The README requires Sphinx 0.6.6 and I have not tested with that version.

In the interests of keeping this project accessible for those who want to build and use it, this pull request removes "comments.html" from the html_sidebars variable in the conf.py.

The `make html` target then builds successfully with both of the above versions and the resulting docs are usable. The other targets continue to build successfully on my system. (Except the dead links check, which was already broken.)

